### PR TITLE
Fix running tests and build for gcc

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -54,7 +54,7 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
     # add relro (mark relocations read only) for all libs
     # add -z,now ("full relro" - more of the Global Offset Table GOT is marked read only)
     # add --no-as-needed to disable default --as-needed link flag on some GCC toolchains
-    BASIC_LDFLAGS="$BASIC_LDFLAGS -Wl,-z,defs -Wl,-z,relro -Wl,-z,now -Wl,--no-as-needed -Wl,--exclude-libs,ALL"
+    BASIC_LDFLAGS="$BASIC_LDFLAGS -Wl,-z,relro -Wl,-z,now -Wl,--no-as-needed -Wl,--exclude-libs,ALL"
     # Linux : remove unused code+data in link step
     if test "x$ENABLE_LINKTIME_GC" = xtrue; then
       if test "x$OPENJDK_TARGET_CPU" = xs390x; then

--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -92,7 +92,7 @@ else
     BUILD_JDK_JTREG_LIBRARIES_JDK_LIBS_libInheritedChannel := java.base:libjava
     BUILD_JDK_JTREG_EXECUTABLES_LIBS_exelauncher := -ldl
   else ifeq ($(call isTargetOs, bsd), true)
-    BUILD_JDK_JTREG_LIBRARIES_LIBS_libInheritedChannel := -ljava
+    BUILD_JDK_JTREG_LIBRARIES_JDK_LIBS_libInheritedChannel := java.base:libjava
     BUILD_JDK_JTREG_EXECUTABLES_LIBS_exelauncher := -pthread
   endif
   ifeq ($(OPENJDK_TARGET_OS_ENV), bsd.openbsd)

--- a/test/jdk/java/io/File/libGetXSpace.c
+++ b/test/jdk/java/io/File/libGetXSpace.c
@@ -30,7 +30,7 @@
 #else
 #include <errno.h>
 #include <string.h>
-#if defined(__APPLE__) || defined(__OpenBSD__)
+#if defined(_ALLBSD_SOURCE)
 #include <sys/param.h>
 #include <sys/mount.h>
 #else


### PR DESCRIPTION
These patches allow the `test-tier1` make target to run, and fixes a tiny snafu in the autoconf files to allow the build to complete using the GCC toolchain.