### PR TITLE
Fix gcc warnings

### DIFF
--- a/src/java.base/unix/native/libjava/childproc.c
+++ b/src/java.base/unix/native/libjava/childproc.c
@@ -51,12 +51,6 @@ closeSafely(int fd)
     return (fd == -1) ? 0 : close(fd);
 }
 
-static int
-isAsciiDigit(char c)
-{
-  return c >= '0' && c <= '9';
-}
-
 #if defined(_BSDONLY_SOURCE)
 /*
  * Quoting POSIX: "If a multi-threaded process calls fork(), the new
@@ -82,6 +76,12 @@ closeDescriptors(void)
     return 1;
 }
 #else
+
+static int
+isAsciiDigit(char c)
+{
+  return c >= '0' && c <= '9';
+}
 
 #if defined(_AIX)
   /* AIX does not understand '/proc/self' - it requires the real process ID */

--- a/src/java.base/unix/native/libnet/NetworkInterface.c
+++ b/src/java.base/unix/native/libnet/NetworkInterface.c
@@ -1788,7 +1788,8 @@ static int getIndex(int sock, const char *name) {
 #else
     struct ifreq if2;
     memset((char *)&if2, 0, sizeof(if2));
-    strncpy(if2.ifr_name, name, sizeof(if2.ifr_name) - 1);
+    strncpy(if2.ifr_name, name, sizeof(if2.ifr_name));
+    if2.ifr_name[sizeof(if2.ifr_name) - 1] = 0;
 
     if (ioctl(sock, SIOCGIFINDEX, (char *)&if2) < 0) {
         return -1;
@@ -1852,7 +1853,8 @@ static int getMTU(JNIEnv *env, int sock, const char *ifname) {
 static int getFlags(int sock, const char *ifname, int *flags) {
     struct ifreq if2;
     memset((char *)&if2, 0, sizeof(if2));
-    strncpy(if2.ifr_name, ifname, sizeof(if2.ifr_name) - 1);
+    strncpy(if2.ifr_name, ifname, sizeof(if2.ifr_name));
+    if2.ifr_name[sizeof(if2.ifr_name) - 1] = 0;
 
     if (ioctl(sock, SIOCGIFFLAGS, (char *)&if2) < 0) {
         return -1;


### PR DESCRIPTION
Get rid of some warnings when using GCC to build OpenJDK, so that it again can be built with warnings as errors enabled.