### PR TITLE
Revert "Prefer IPv4 and disable IPV6_V6ONLY on all BSD"

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/SystemProps.java
+++ b/src/java.base/share/classes/jdk/internal/util/SystemProps.java
@@ -122,7 +122,6 @@ public final class SystemProps {
         putIfAbsent(props, "http.nonProxyHosts", raw.propDefault(Raw._http_nonProxyHosts_NDX));
         putIfAbsent(props, "ftp.nonProxyHosts", raw.propDefault(Raw._ftp_nonProxyHosts_NDX));
         putIfAbsent(props, "socksNonProxyHosts", raw.propDefault(Raw._socksNonProxyHosts_NDX));
-        putIfAbsent(props, "java.net.preferIPv4Stack", raw.propDefault(Raw._java_net_preferIPV4Stack_NDX));
         putIfAbsent(props, "sun.arch.abi", raw.propDefault(Raw._sun_arch_abi_NDX));
         putIfAbsent(props, "sun.arch.data.model", raw.propDefault(Raw._sun_arch_data_model_NDX));
         putIfAbsent(props, "sun.os.patch.level", raw.propDefault(Raw._sun_os_patch_level_NDX));
@@ -234,8 +233,7 @@ public final class SystemProps {
         @Native private static final int _https_proxyHost_NDX = 1 + _http_proxyPort_NDX;
         @Native private static final int _https_proxyPort_NDX = 1 + _https_proxyHost_NDX;
         @Native private static final int _java_io_tmpdir_NDX = 1 + _https_proxyPort_NDX;
-        @Native private static final int _java_net_preferIPV4Stack_NDX = 1 + _java_io_tmpdir_NDX;
-        @Native private static final int _line_separator_NDX = 1 +_java_net_preferIPV4Stack_NDX;
+        @Native private static final int _line_separator_NDX = 1 + _java_io_tmpdir_NDX;
         @Native private static final int _os_arch_NDX = 1 + _line_separator_NDX;
         @Native private static final int _os_name_NDX = 1 + _os_arch_NDX;
         @Native private static final int _os_version_NDX = 1 + _os_name_NDX;

--- a/src/java.base/share/native/libjava/System.c
+++ b/src/java.base/share/native/libjava/System.c
@@ -199,8 +199,8 @@ Java_jdk_internal_util_SystemProps_00024Raw_platformProperties(JNIEnv *env, jcla
     }
 #endif
 
-#ifdef _BSDONLY_SOURCE
-    PUTPROP(propArray, _java_net_preferIPV4Stack_NDX, sprops->java_net_preferIPv4Stack);
+#ifdef __OpenBSD__
+    PUTPROP(props, "java.net.preferIPv4Stack", sprops->java_net_preferIPv4Stack);
 #endif
 
     /* data model */

--- a/src/java.base/share/native/libjava/java_props.h
+++ b/src/java.base/share/native/libjava/java_props.h
@@ -102,7 +102,7 @@ typedef struct {
     char *exceptionList;
 #endif
 
-#ifdef _BSDONLY_SOURCE
+#ifdef __OpenBSD__
     char *java_net_preferIPv4Stack; /* Needed to default to true OpenBSD. */
 #endif
 

--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -382,7 +382,7 @@ GetJavaProperties(JNIEnv *env)
     /* patches/service packs installed */
     sprops.patch_level = NULL;      // leave it undefined
 
-#ifdef _BSDONLY_SOURCE
+#ifdef __OpenBSD__
     sprops.java_net_preferIPv4Stack = "true";
 #endif
 

--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -285,7 +285,7 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
         return handleSocketError(env, errno);
     }
 
-#ifndef _BSDONLY_SOURCE
+#ifndef __OpenBSD__
     /*
      * If IPv4 is available, disable IPV6_V6ONLY to ensure dual-socket support.
      */


### PR DESCRIPTION
The rationale for limiting connections to IPv4 only on FreeBSD seems to no longer hold. Reverting these changes allow both server and client connections to dual protocol sockets.

This reverts commit ed1e0ab9b8cef21b3b6924da230e7b3ba0bf19de which references 901e4eb0d5299d0550e743347c41a057a8b24276 for rationale.

This work is sponsored by The FreeBSD Foundation.